### PR TITLE
use feature 'switch' for <when> on perl 5.10.1 Debian 6.0.8

### DIFF
--- a/lib/Data/Domain.pm
+++ b/lib/Data/Domain.pm
@@ -5,6 +5,7 @@ use 5.010;
 use strict;
 use warnings;
 use experimental 'smartmatch';
+use feature 'switch';
 use Carp;
 use Data::Dumper;
 use Scalar::Does 0.007;


### PR DESCRIPTION
commit to remove following error:

"my" variable $min masks earlier declaration in same statement at /home/k.yakunin/perl5/lib/perl5/Data/Domain.pm line 421.
"my" variable $max masks earlier declaration in same statement at /home/k.yakunin/perl5/lib/perl5/Data/Domain.pm line 421.
"my" variable $self masks earlier declaration in same scope at /home/k.yakunin/perl5/lib/perl5/Data/Domain.pm line 427.
syntax error at /home/k.yakunin/perl5/lib/perl5/Data/Domain.pm line 411, near ") {"
syntax error at /home/k.yakunin/perl5/lib/perl5/Data/Domain.pm line 412, near ") {"
Global symbol "$cmp_func" requires explicit package name at /home/k.yakunin/perl5/lib/perl5/Data/Domain.pm line 412.
syntax error at /home/k.yakunin/perl5/lib/perl5/Data/Domain.pm line 423, near "}"
Can't use global @_ in "my" at /home/k.yakunin/perl5/lib/perl5/Data/Domain.pm line 427, near "= @_"
BEGIN not safe after errors--compilation aborted at /home/k.yakunin/perl5/lib/perl5/Data/Domain.pm line 428.
